### PR TITLE
template command - output conformity and yaml linting

### DIFF
--- a/cmd/helm/template.go
+++ b/cmd/helm/template.go
@@ -303,7 +303,7 @@ func writeToFile(outputDir string, name string, data string) error {
 
 	defer f.Close()
 
-	_, err = f.WriteString(fmt.Sprintf("##---\n# Source: %s\n%s", name, data))
+	_, err = f.WriteString(fmt.Sprintf("---\n# Source: %s\n%s", name, data))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
# Woops, made a PR to my own forks master...

## About 
This is a trivial PR code wise, with two benefits: output conformity and yaml linting

## Output conformity
When the `helm template` command is writing output to files, it looks like this:
```yaml
##---
# Source: jupyterhub/templates/image-puller/job.yaml
```
_Related code..._
https://github.com/kubernetes/helm/blob/58e4b6ac61938fe056037826225dd19562c0ed9f/cmd/helm/template.go#L306

But if it writes output to stdout, it looks like this:
```yaml
---
# Source: jupyterhub/templates/image-puller/job.yaml
```
_Related code..._
https://github.com/kubernetes/helm/blob/58e4b6ac61938fe056037826225dd19562c0ed9f/cmd/helm/template.go#L284-L285

## Yaml linting
The extra `##` causes some warnings with [yaml linter](https://github.com/adrienverge/yamllint) using the default yaml linting rules, and errors if one makes them stricter.

#### A yaml linter with default settings run on `helm template`'s output
![yamllint](https://user-images.githubusercontent.com/3837114/38236729-6373eeda-3725-11e8-8256-e210c7fcdbb3.gif)

## PS
If there was a point to having the two hashtags in front of the three hyphens, we could perhaps at least change it from `##---` to `# ---`? That would get rid of one yaml linter warning regarding comment spacing.